### PR TITLE
Added support for Hex/Octal/Binary literals as numbers

### DIFF
--- a/test/rSON.cpp
+++ b/test/rSON.cpp
@@ -21,6 +21,8 @@
 // wrappers for testing and must be compiled the same
 // as the library's own sources so it gets included in gcov.
 
+#include <array>
+
 #include "test.h"
 #include "testHeader.h"
 

--- a/test/testParser.cpp
+++ b/test/testParser.cpp
@@ -142,6 +142,10 @@ void testIntNumber()
 	tryNumberOk("-0 ", [](const JSONAtom &atom) { assertIntEqual(atom.asInt(), -0); });
 	tryNumberOk("19e1 ", [](const JSONAtom &atom) { assertIntEqual(atom.asInt(), 190); });
 	tryNumberOk("190e-1 ", [](const JSONAtom &atom) { assertIntEqual(atom.asInt(), 19); });
+	tryNumberOk("0xFF ", [](const JSONAtom &atom) { assertIntEqual(atom.asInt(), 255); });
+	tryNumberOk("0o666 ", [](const JSONAtom &atom) { assertIntEqual(atom.asInt(), 438); });
+	tryNumberOk("0b111 ", [](const JSONAtom &atom) { assertIntEqual(atom.asInt(), 7); });
+
 
 	tryNumberFail("");
 	tryNumberFail("-");


### PR DESCRIPTION
This commit adds support hex, octal, and binary literals as valid values for numeric literals in JSON files.


This also fixes an error with the test harness due to a missing include.


:cat: